### PR TITLE
Version 1.2.9.0 

### DIFF
--- a/MSGraph/MSGraph.psd1
+++ b/MSGraph/MSGraph.psd1
@@ -1,9 +1,9 @@
 ﻿@{
     # Script module or binary module file associated with this manifest
-    ModuleToProcess    = 'MSGraph.psm1'
+    RootModule         = 'MSGraph.psm1'
 
     # Version number of this module.
-    ModuleVersion      = '1.2.8.5'
+    ModuleVersion      = '1.2.9.0'
 
     # ID used to uniquely identify this module
     GUID               = '5f61c229-95d0-4423-ab50-938c0723ad21'

--- a/MSGraph/changelog.md
+++ b/MSGraph/changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 # 1.2.9.0
--
+- Fix: Command Export-MgaMailAttachment
+    - bugfixing type checking for attachments to export. Types are renamed in version 1.2.8.3 and the command test for the old type names
+
 
 # 1.2.8.5
 - New: Command Get-MgaMailboxSettings

--- a/MSGraph/changelog.md
+++ b/MSGraph/changelog.md
@@ -1,4 +1,7 @@
 # Changelog
+# 1.2.9.0
+-
+
 # 1.2.8.5
 - New: Command Get-MgaMailboxSettings
     - returns the settings from the exchange online mailbox

--- a/MSGraph/functions/exchange/attachment/Export-MgaMailAttachment.ps1
+++ b/MSGraph/functions/exchange/attachment/Export-MgaMailAttachment.ps1
@@ -55,20 +55,20 @@
         foreach ($attachmentItem in $Attachment) {
             #switching between different types to export
             switch ($attachmentItem.TypeName) {
-                "MSGraph.Exchange.Mail.Attachment.FileAttachment" {
+                "MSGraph.Exchange.Attachment.FileAttachment" {
                     if ($pscmdlet.ShouldProcess($attachmentItem, "Export to $($Path.Path)")) {
-                        Write-PSFMessage -Level Verbose -Message "Exporting attachment '$($attachmentItem)' to $($Path.Path)" -Tag "ExportData"
+                        Write-PSFMessage -Level Verbose -Message "Exporting attachment '$($attachmentItem)' to '$($Path.ToString())'" -Tag "ExportData"
                         $attachmentItem.InputObject.ContentBytes | Set-Content -Path (Join-Path -Path $Path -ChildPath $attachmentItem.Name) -Encoding Byte
                     }
                 }
 
-                "MSGraph.Exchange.Mail.Attachment.ItemAttachment" {
+                "MSGraph.Exchange.Attachment.ItemAttachment" {
                     if ($pscmdlet.ShouldProcess($attachmentItem, "Export to $($Path.Path)")) {
                         Write-PSFMessage -Level Important -Message "Export of $($attachmentItem.TypeName) is not implemented, yet. Could not export '$($attachmentItem.InputObject)'" -Tag "ExportData"
                     }
                 }
 
-                "MSGraph.Exchange.Mail.Attachment.ReferenceAttachment" {
+                "MSGraph.Exchange.Attachment.ReferenceAttachment" {
                     if ($pscmdlet.ShouldProcess($attachmentItem, "Export to $($Path.Path)")) {
                         $shell = New-Object -ComObject ("WScript.Shell")
                         $shortCut = $shell.CreateShortcut("$($Path.Path)\$($attachmentItem.InputObject.Name).lnk")
@@ -77,7 +77,7 @@
                     }
                 }
 
-                "MSGraph.Exchange.Mail.Attachment.Attachment" {
+                "MSGraph.Exchange.Attachment.Attachment" {
                     Write-PSFMessage -Level Warning -Message "$($attachmentItem) is not a exportable attachment." -Tag "ParameterSetHandling"
                 }
 


### PR DESCRIPTION
# 1.2.9.0 
- Fix: Command Export-MgaMailAttachment 
    - bugfixing type checking for attachments to export. Types are renamed in version 1.2.8.3 and the command test for the old type names 